### PR TITLE
Add vidscraper-cmd.

### DIFF
--- a/bin/vidscraper-cmd
+++ b/bin/vidscraper-cmd
@@ -1,4 +1,6 @@
-# Copyright 2009 - Participatory Culture Foundation
+#!/usr/bin/env python
+
+# Copyright 2012 - Participatory Culture Foundation
 #
 # This file is part of vidscraper.
 #
@@ -23,18 +25,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import datetime
 
-try:
-    import json
-except ImportError:
-    try:
-        import simplejson as json
-    except ImportError:
-        raise ImportError("simplejson or native json must be installed.")
+import sys
+import vidscraper
 
 
-def json_dump_helper(obj):
-    if isinstance(obj, datetime.datetime):
-        return obj.isoformat()
-    raise TypeError("%s is not serializable" % repr(obj))
+if __name__ == "__main__":
+    sys.exit(vidscraper.VidscraperCommandHandler().main())

--- a/docs/topics/vidscraper_cmd.rst
+++ b/docs/topics/vidscraper_cmd.rst
@@ -1,0 +1,44 @@
+.. Copyright 2012 - Participatory Culture Foundation
+
+   This file is part of vidscraper.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS`` AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Command Line
+============
+
+vidscraper comes with a command line utility allowing you to do crazy
+awesome things on the command line.
+
+Want to get the metadata for a YouTube video?
+
+::
+
+    $ vidscraper-cmd video http://www.youtube.com/watch?v=J_DV9b0x7v4
+
+
+Want just the title and embed code?
+
+::
+
+    $ vidscraper-cmd video --fields=title,embed_code \
+        http://www.youtube.com/watch?v=J_DV9b0x7v4

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Participatory Culture Foundation',
     license='BSD',
     packages=find_packages(),
+    scripts=['bin/vidscraper-cmd'],
     install_requires=[
         'lxml',
         'oauth2',

--- a/vidscraper/__init__.py
+++ b/vidscraper/__init__.py
@@ -24,8 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
+from optparse import OptionParser
 from vidscraper import errors
 from vidscraper.suites import Video, registry, VideoSearch, VideoFeed
+import pprint
 
 
 VERSION = '0.5.0a'
@@ -112,3 +115,76 @@ def auto_search(query, fields=None, order_by=None, crawl=False,
             suites[suite] = search
         
     return suites
+
+
+# fetchvideo -> auto_scrape(url, fields, api_keys)
+
+
+class CommandHandler(object):
+    usage = "%prog [command] [options]"
+
+    def get_commands(self):
+        return [mem.replace("handle_", "")
+                for mem in dir(self)
+                if mem.startswith("handle_")]
+
+    def build_parser(self, usage):
+        parser = OptionParser(usage=usage, version=__version__)
+        return parser
+
+    def handle_video(self):
+        parser = self.build_parser("%prog video [options] URL")
+        parser.add_option("--fields", dest="fields",
+                          help="comma-separated list of fields to retrieve. "
+                          "e.g. --fields=a,b,c")
+        parser.add_option("--apikeys", dest="api_keys",
+                          help="api keys comma separated. "
+                          "e.g. --apikeys=key:val,key2:val")
+        (options, args) = parser.parse_args()
+
+        if len(args) == 0:
+            parser.error("URL needed.")
+
+        if options.fields:
+            fields = options.fields.split(",")
+        else:
+            fields = None
+
+        if options.api_keys:
+            api_keys = dict(mem.split(":")
+                            for mem in options.api_keys.split(","))
+        else:
+            api_keys = None
+
+        for arg in args:
+            print "Scraping %s" % arg
+            video = auto_scrape(arg, fields=fields, api_keys=api_keys)
+            print video.to_json(indent=2, sort_keys=True)
+
+    def handle_help(self, error=None):
+        parser = self.build_parser("%prog [command]")
+        parser.print_help()
+        if error:
+            print ""
+            print "Error: " + error
+        print ""
+        print "Commands:"
+        for cmd in self.get_commands():
+            print "    %s" % cmd
+        return 0
+
+    def main(self):
+        if len(sys.argv) <= 1 or sys.argv[1] in ("-h", "--help"):
+            return self.handle_help()
+
+        try:
+            cmd = sys.argv.pop(1)
+            cmd = "".join(c for c in cmd if c.isalpha())
+            handler = getattr(self, "handle_%s" % cmd)
+        except AttributeError:
+            return self.handle_help(error='%s is not a valid command.' % cmd)
+
+        return handler()
+
+if __name__ == "__main__":
+    sys.exit(CommandHandler().main())

--- a/vidscraper/__init__.py
+++ b/vidscraper/__init__.py
@@ -120,19 +120,31 @@ def auto_search(query, fields=None, order_by=None, crawl=False,
 # fetchvideo -> auto_scrape(url, fields, api_keys)
 
 
-class CommandHandler(object):
+class VidscraperCommandHandler(object):
+    """Command line handler for vidscraper.
+
+    This exposes functions in this module to the command line giving
+    vidscraper command line utility.
+
+    Subcommands are implemented in ``handle_SUBCOMMAND`` methods.  See
+    ``handle_video`` and ``handle_help`` for examples.
+    """
+
     usage = "%prog [command] [options]"
 
     def get_commands(self):
+        """Returns a list of subcommands implemented."""
         return [mem.replace("handle_", "")
                 for mem in dir(self)
                 if mem.startswith("handle_")]
 
     def build_parser(self, usage):
+        """Builds the parser with universal bits."""
         parser = OptionParser(usage=usage, version=__version__)
         return parser
 
     def handle_video(self):
+        """Handler for auto_scrape."""
         parser = self.build_parser("%prog video [options] URL")
         parser.add_option("--fields", dest="fields",
                           help="comma-separated list of fields to retrieve. "
@@ -151,7 +163,7 @@ class CommandHandler(object):
             fields = None
 
         if options.api_keys:
-            api_keys = dict(mem.split(":")
+            api_keys = dict(mem.split(":", 1)
                             for mem in options.api_keys.split(","))
         else:
             api_keys = None
@@ -161,7 +173,10 @@ class CommandHandler(object):
             video = auto_scrape(arg, fields=fields, api_keys=api_keys)
             print video.to_json(indent=2, sort_keys=True)
 
+        return 0
+
     def handle_help(self, error=None):
+        """Handles help."""
         parser = self.build_parser("%prog [command]")
         parser.print_help()
         if error:
@@ -187,4 +202,4 @@ class CommandHandler(object):
         return handler()
 
 if __name__ == "__main__":
-    sys.exit(CommandHandler().main())
+    sys.exit(VidscraperCommandHandler().main())

--- a/vidscraper/suites/base.py
+++ b/vidscraper/suites/base.py
@@ -29,7 +29,7 @@ import urllib2
 
 import feedparser
 
-from vidscraper.compat import json
+from vidscraper.compat import json, json_dump_helper
 from vidscraper.errors import CantIdentifyUrl, VideoDeleted
 from vidscraper.utils.feedparser import (struct_time_to_datetime,
                                          get_item_thumbnail_url)
@@ -221,8 +221,8 @@ class Video(object):
 
     def items(self):
         """Iterator over (field, value) for requested fields."""
-        for mem in self.fields:
-            yield (mem, getattr(self, mem))
+        for field in self.fields:
+            yield (field, getattr(self, field))
 
     def to_json(self, **kw):
         """Returns the video JSON-ified.
@@ -233,6 +233,7 @@ class Video(object):
 
         >>> v.to_json(indent=2, sort_keys=True)
         """
+        kw['default'] = json_dump_helper
         return json.dumps(dict(self.items()), **kw)
 
     def load(self):

--- a/vidscraper/suites/base.py
+++ b/vidscraper/suites/base.py
@@ -219,6 +219,22 @@ class Video(object):
         """The suite to be used for scraping this video."""
         return self._suite
 
+    def items(self):
+        """Iterator over (field, value) for requested fields."""
+        for mem in self.fields:
+            yield (mem, getattr(self, mem))
+
+    def to_json(self, **kw):
+        """Returns the video JSON-ified.
+
+        Takes keyword arguments and passes them to json.dumps().
+
+        Example:
+
+        >>> v.to_json(indent=2, sort_keys=True)
+        """
+        return json.dumps(dict(self.items()), **kw)
+
     def load(self):
         """Uses the video's :attr:`suite` to fetch the fields for the video."""
         if not self._loaded:

--- a/vidscraper/tests/unit/test_video.py
+++ b/vidscraper/tests/unit/test_video.py
@@ -1,4 +1,4 @@
-# Copyright 2009 - Participatory Culture Foundation
+# Copyright 2012 - Participatory Culture Foundation
 #
 # This file is part of vidscraper.
 #
@@ -23,18 +23,37 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import datetime
+import unittest
 
-try:
-    import json
-except ImportError:
-    try:
-        import simplejson as json
-    except ImportError:
-        raise ImportError("simplejson or native json must be installed.")
+from nose.tools import eq_
+
+from vidscraper import auto_scrape
+from vidscraper.compat import json
+from vidscraper.suites.base import Video
 
 
-def json_dump_helper(obj):
-    if isinstance(obj, datetime.datetime):
-        return obj.isoformat()
-    raise TypeError("%s is not serializable" % repr(obj))
+class VideoTestCase(unittest.TestCase):
+    def test_items(self):
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+
+        # Make sure items can be iterated over and that there's one
+        # for every field.
+        for i, item in enumerate(video.items()):
+            eq_(item[0], Video._all_fields[i])
+
+    def test_items_with_fields(self):
+        fields = ['title', 'user']
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4",
+                            fields)
+
+        # Make sure items can be iterated over and that there's one
+        # for every field.
+        for i, item in enumerate(video.items()):
+            eq_(item[0], fields[i])
+
+    def test_to_json(self):
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+
+        data_json = video.to_json()
+        # Verify that we can load the json back into Python.
+        json.loads(data_json)


### PR DESCRIPTION
This adds the beginnings of a vidscraper-cmd. It supports auto-scraping
videos, but nothing else, yet. However, the code is written such that
adding support for other actions is easy to do.

The video subcommand supports specifying fields to be returned and also
api keys (though the latter is untested).

It returns data in JSON format--which required adding `items()` and
`to_json()` methods to the Video class.

Also adds a new topic in the documentation.

Closes #6.
