### PR TITLE
Add vidscraper-cmd.

### DIFF
--- a/bin/vidscraper-cmd
+++ b/bin/vidscraper-cmd
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - Participatory Culture Foundation
+#
+# This file is part of vidscraper.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import sys
+import vidscraper
+
+
+if __name__ == "__main__":
+    sys.exit(vidscraper.VidscraperCommandHandler().main())

--- a/docs/topics/vidscraper_cmd.rst
+++ b/docs/topics/vidscraper_cmd.rst
@@ -1,0 +1,44 @@
+.. Copyright 2012 - Participatory Culture Foundation
+
+   This file is part of vidscraper.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS`` AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Command Line
+============
+
+vidscraper comes with a command line utility allowing you to do crazy
+awesome things on the command line.
+
+Want to get the metadata for a YouTube video?
+
+::
+
+    $ vidscraper-cmd video http://www.youtube.com/watch?v=J_DV9b0x7v4
+
+
+Want just the title and embed code?
+
+::
+
+    $ vidscraper-cmd video --fields=title,embed_code \
+        http://www.youtube.com/watch?v=J_DV9b0x7v4

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/pculture/vidscraper',
     license='BSD',
     packages=find_packages(),
+    scripts=['bin/vidscraper-cmd'],
     install_requires=[
         'lxml>=2.3.4',
         'oauth2>=1.5.211',

--- a/vidscraper/__init__.py
+++ b/vidscraper/__init__.py
@@ -118,19 +118,31 @@ def auto_search(query, fields=None, order_by=None, crawl=False,
 # fetchvideo -> auto_scrape(url, fields, api_keys)
 
 
-class CommandHandler(object):
+class VidscraperCommandHandler(object):
+    """Command line handler for vidscraper.
+
+    This exposes functions in this module to the command line giving
+    vidscraper command line utility.
+
+    Subcommands are implemented in ``handle_SUBCOMMAND`` methods.  See
+    ``handle_video`` and ``handle_help`` for examples.
+    """
+
     usage = "%prog [command] [options]"
 
     def get_commands(self):
+        """Returns a list of subcommands implemented."""
         return [mem.replace("handle_", "")
                 for mem in dir(self)
                 if mem.startswith("handle_")]
 
     def build_parser(self, usage):
+        """Builds the parser with universal bits."""
         parser = OptionParser(usage=usage, version=__version__)
         return parser
 
     def handle_video(self):
+        """Handler for auto_scrape."""
         parser = self.build_parser("%prog video [options] URL")
         parser.add_option("--fields", dest="fields",
                           help="comma-separated list of fields to retrieve. "
@@ -149,7 +161,7 @@ class CommandHandler(object):
             fields = None
 
         if options.api_keys:
-            api_keys = dict(mem.split(":")
+            api_keys = dict(mem.split(":", 1)
                             for mem in options.api_keys.split(","))
         else:
             api_keys = None
@@ -159,7 +171,10 @@ class CommandHandler(object):
             video = auto_scrape(arg, fields=fields, api_keys=api_keys)
             print video.to_json(indent=2, sort_keys=True)
 
+        return 0
+
     def handle_help(self, error=None):
+        """Handles help."""
         parser = self.build_parser("%prog [command]")
         parser.print_help()
         if error:
@@ -185,4 +200,4 @@ class CommandHandler(object):
         return handler()
 
 if __name__ == "__main__":
-    sys.exit(CommandHandler().main())
+    sys.exit(VidscraperCommandHandler().main())

--- a/vidscraper/tests/unit/test_video.py
+++ b/vidscraper/tests/unit/test_video.py
@@ -1,0 +1,59 @@
+# Copyright 2012 - Participatory Culture Foundation
+#
+# This file is part of vidscraper.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from nose.tools import eq_
+
+from vidscraper import auto_scrape
+from vidscraper.compat import json
+from vidscraper.suites.base import Video
+
+
+class VideoTestCase(unittest.TestCase):
+    def test_items(self):
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+
+        # Make sure items can be iterated over and that there's one
+        # for every field.
+        for i, item in enumerate(video.items()):
+            eq_(item[0], Video._all_fields[i])
+
+    def test_items_with_fields(self):
+        fields = ['title', 'user']
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4",
+                            fields)
+
+        # Make sure items can be iterated over and that there's one
+        # for every field.
+        for i, item in enumerate(video.items()):
+            eq_(item[0], fields[i])
+
+    def test_to_json(self):
+        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+
+        data_json = video.to_json()
+        # Verify that we can load the json back into Python.
+        json.loads(data_json)

--- a/vidscraper/tests/unit/test_video.py
+++ b/vidscraper/tests/unit/test_video.py
@@ -24,35 +24,32 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+import json
 
-from nose.tools import eq_
-
-from vidscraper import auto_scrape
-from vidscraper.compat import json
-from vidscraper.suites.base import Video
+from vidscraper.videos import Video
 
 
 class VideoTestCase(unittest.TestCase):
     def test_items(self):
-        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+        video = Video("http://www.youtube.com/watch?v=J_DV9b0x7v4")
 
         # Make sure items can be iterated over and that there's one
         # for every field.
         for i, item in enumerate(video.items()):
-            eq_(item[0], Video._all_fields[i])
+            self.assertEqual(item[0], Video._all_fields[i])
 
     def test_items_with_fields(self):
         fields = ['title', 'user']
-        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4",
-                            fields)
+        video = Video("http://www.youtube.com/watch?v=J_DV9b0x7v4",
+                            fields=fields)
 
         # Make sure items can be iterated over and that there's one
         # for every field.
         for i, item in enumerate(video.items()):
-            eq_(item[0], fields[i])
+            self.assertEqual(item[0], fields[i])
 
     def test_to_json(self):
-        video = auto_scrape("http://www.youtube.com/watch?v=J_DV9b0x7v4")
+        video = Video("http://www.youtube.com/watch?v=J_DV9b0x7v4")
 
         data_json = video.to_json()
         # Verify that we can load the json back into Python.

--- a/vidscraper/videos.py
+++ b/vidscraper/videos.py
@@ -24,6 +24,7 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import datetime
 
 from vidscraper.exceptions import UnhandledURL, VideoDeleted
 from vidscraper.utils.search import (search_string_from_terms,
@@ -170,6 +171,12 @@ class Video(object):
 
         >>> v.to_json(indent=2, sort_keys=True)
         """
+        def json_dump_helper(obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.isoformat()
+            raise TypeError("%r is not serializable" % (obj,))
+
+        kw['default'] = json_dump_helper
         return json.dumps(dict(self.items()), **kw)
 
 

--- a/vidscraper/videos.py
+++ b/vidscraper/videos.py
@@ -23,6 +23,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 
 from vidscraper.exceptions import UnhandledURL, VideoDeleted
 from vidscraper.utils.search import (search_string_from_terms,
@@ -154,6 +155,22 @@ class Video(object):
 
     def is_loaded(self):
         return self._loaded
+
+    def items(self):
+        """Iterator over (field, value) for requested fields."""
+        for mem in self.fields:
+            yield (mem, getattr(self, mem))
+
+    def to_json(self, **kw):
+        """Returns the video JSON-ified.
+
+        Takes keyword arguments and passes them to json.dumps().
+
+        Example:
+
+        >>> v.to_json(indent=2, sort_keys=True)
+        """
+        return json.dumps(dict(self.items()), **kw)
 
 
 class BaseVideoIterator(object):


### PR DESCRIPTION
This adds the beginnings of a vidscraper-cmd. It supports auto-scraping
videos, but nothing else, yet. However, the code is written such that
adding support for other actions is easy to do.

The video subcommand supports specifying fields to be returned and also
api keys (though the latter is untested).

It returns data in JSON format--which required adding items() and
to_json() methods to the Video class.

Also adds a new topic in the documentation.

Closes #6.

(originally from https://github.com/pculture/vidscraper/pull/7)
