### PR TITLE
Fix vidscraper to work with requests >= 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
     install_requires=[
         'feedparser>=5.1.2',
         'beautifulsoup4>=4.0.2',
-        'requests>=0.13.0,<1.0.0',
+        # 'requests>=0.13.0,<1.0.0',
+        'requests>=1.0.0',
         'lxml>=2.3.4',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     install_requires=[
         'feedparser>=5.1.2',
         'beautifulsoup4>=4.0.2',
-        # 'requests>=0.13.0,<1.0.0',
         'requests>=1.0.0',
         'lxml>=2.3.4',
     ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.1.3
 feedparser==5.1.3
 lxml==3.0
 mock==1.0.1
-requests==0.14.2
+requests==1.2.2
 requests-oauth==0.4.1
 unittest2==0.5.1
 vidscraper==1.0.1

--- a/vidscraper/suites/vimeo.py
+++ b/vidscraper/suites/vimeo.py
@@ -114,7 +114,7 @@ class SimpleLoader(PathMixin, VideoLoader):
     url_format = u"http://vimeo.com/api/v2/video/{video_id}.json"
 
     def get_video_data(self, response):
-        return Suite.simple_api_video_to_data(response.json[0])
+        return Suite.simple_api_video_to_data(response.json()[0])
 
 
 class AdvancedLoader(AdvancedApiMixin, PathMixin, VideoLoader):
@@ -131,7 +131,7 @@ class AdvancedLoader(AdvancedApiMixin, PathMixin, VideoLoader):
 
     def get_video_data(self, response):
         return AdvancedApiMixin.get_video_data(self,
-                                               response.json['video'][0])
+                                               response.json()['video'][0])
 
 
 class SimpleFeed(BaseFeed):
@@ -223,7 +223,7 @@ class SimpleFeed(BaseFeed):
     def get_response_items(self, response):
         if response.status_code == 403:
             return []
-        return response.json
+        return response.json()
 
     def get_video_data(self, item):
         return Suite.simple_api_video_to_data(item)
@@ -257,26 +257,26 @@ class SimpleFeed(BaseFeed):
         """
         data = {}
         # User is very different
-        if "display_name" in response.json:
-            display_name = response.json['display_name']
+        if "display_name" in response.json():
+            display_name = response.json()['display_name']
             request_type = (self.url_data['request_type'] if
                             self.url_data['request_type'] in
                             ('videos', 'likes', 'appears_in',
                              'all_videos', 'subscriptions')
                             else 'videos')
             count = None
-            webpage = response.json['profile_url']
+            webpage = response.json()['profile_url']
             if request_type == 'videos':
                 title = "{0}'s videos".format(display_name)
-                count = response.json['total_videos_uploaded']
-                webpage = response.json['videos_url']
+                count = response.json()['total_videos_uploaded']
+                webpage = response.json()['videos_url']
             elif request_type == 'likes':
                 title = 'Videos {0} likes'.format(display_name)
-                count = response.json['total_videos_liked']
+                count = response.json()['total_videos_liked']
                 webpage = "{0}/likes".format(webpage)
             elif request_type == 'appears_in':
                 title = "Videos {0} appears in".format(display_name)
-                count = response.json['total_videos_appears_in']
+                count = response.json()['total_videos_appears_in']
             elif request_type == 'all_videos':
                 title = "{0}'s videos and videos {0} appears in".format(
                             display_name)
@@ -287,33 +287,33 @@ class SimpleFeed(BaseFeed):
                 # if this is the simple API, we can only get up to 60 videos;
                 # if it's the advanced API, this will be overridden anyway.
                 'video_count': min(count, 60),
-                'description': response.json['bio'],
+                'description': response.json()['bio'],
                 'webpage': webpage,
-                'thumbnail_url': response.json['portrait_huge']
+                'thumbnail_url': response.json()['portrait_huge']
             })
         else:
             # It's a channel, album, or group feed.
 
             # Title - albums use 'title'; channels/groups use 'name'
-            if "title" in response.json:
-                title = response.json['title']
+            if "title" in response.json():
+                title = response.json()['title']
             else:
-                title = response.json['name']
+                title = response.json()['name']
 
             # Albums and groups have a small thumbnail (~100x75). Groups and
             # channels have a large logo, as well, but it seems like a paid
             # feature - some groups/channels have a blank value there.
-            thumbnail_url = response.json.get('logo')
-            if not thumbnail_url and 'thumbnail' in response.json:
-                thumbnail_url = response.json['thumbnail']
+            thumbnail_url = response.json().get('logo')
+            if not thumbnail_url and 'thumbnail' in response.json():
+                thumbnail_url = response.json()['thumbnail']
 
             data.update({
                 'title': title,
                 # if this is the simple API, we can only get up to 60 videos;
                 # if it's the advanced API, this will be overridden anyway.
-                'video_count': min(response.json['total_videos'], 60),
-                'description': response.json['description'],
-                'webpage': response.json['url'],
+                'video_count': min(response.json()['total_videos'], 60),
+                'description': response.json()['description'],
+                'webpage': response.json()['url'],
                 'thumbnail_url': thumbnail_url
             })
 
@@ -337,21 +337,21 @@ class AdvancedIteratorMixin(AdvancedApiMixin):
     def data_from_response(self, response):
         # Advanced api doesn't have etags, but it does have explicit
         # video counts.
-        if 'videos' not in response.json:
+        if 'videos' not in response.json():
             video_count = 0
         else:
-            video_count = int(response.json['videos']['total'])
+            video_count = int(response.json()['videos']['total'])
         return {'video_count': video_count}
 
     def get_response_items(self, response):
-        if 'videos' not in response.json:
+        if 'videos' not in response.json():
             return []
 
         # A blank page will not include the 'video' key.
-        if response.json['videos']['on_this_page'] == 0:
+        if response.json()['videos']['on_this_page'] == 0:
             return []
 
-        return response.json['videos']['video']
+        return response.json()['videos']['video']
 
 
 class Search(AdvancedIteratorMixin, BaseSearch):

--- a/vidscraper/suites/youtube.py
+++ b/vidscraper/suites/youtube.py
@@ -271,10 +271,10 @@ class Feed(ApiMixin, BaseFeed):
         raise UnhandledFeed(url)
 
     def get_response_items(self, response):
-        return response.json['feed'].get('entry', [])
+        return response.json()['feed'].get('entry', [])
 
     def data_from_response(self, response):
-        feed = response.json['feed']
+        feed = response.json()['feed']
         for l in feed['link']:
             if l['rel'] == 'alternate':
                 link = l['href']
@@ -286,7 +286,7 @@ class Feed(ApiMixin, BaseFeed):
             'title': feed['title']['$t'],
             'webpage': link,
             'guid': feed['id']['$t'],
-            'etag': response.headers['etag'] or feed['gd$etag'],
+            'etag': response.headers.get('etag') or feed['gd$etag'],
             'thumbnail_url': feed['logo']['$t'],
         }
 
@@ -309,14 +309,14 @@ class Search(ApiMixin, BaseSearch):
         # search results (max 999).
         if response.status_code == 400:
             return []
-        return response.json['feed'].get('entry', [])
+        return response.json()['feed'].get('entry', [])
 
     def data_from_response(self, response):
         # Response will have a 400 error code (and no useful metadata) if
         # we're beyond the end of the search results (max 999).
         if response.status_code == 400:
             return {}
-        feed = response.json['feed']
+        feed = response.json()['feed']
         return {
             'video_count': feed['openSearch$totalResults']['$t'],
         }

--- a/vidscraper/tests/integration/test_vimeo.py
+++ b/vidscraper/tests/integration/test_vimeo.py
@@ -59,6 +59,7 @@ right to choose after the National Day of Action Rally to Stop Stupak-Pitts, \
             }
 
         for key, value in expected.items():
+            print value, getattr(video, key)
             self.assertEqual(value, getattr(video, key))
 
     def test_feed(self):

--- a/vidscraper/tests/unit/test_vimeo.py
+++ b/vidscraper/tests/unit/test_vimeo.py
@@ -376,7 +376,8 @@ class AdvancedFeedTestCase(VimeoTestCase):
         If the page has 0 videos on it, no response items should be returned.
 
         """
-        response = mock.MagicMock(json={'videos': {'on_this_page': 0}})
+        response = mock.MagicMock()
+        response.json.return_value = {'videos': {'on_this_page': 0}}
         items = self.feed.get_response_items(response)
         self.assertEqual(len(items), 0)
 
@@ -386,7 +387,8 @@ class AdvancedFeedTestCase(VimeoTestCase):
         should be returned.
 
         """
-        response = mock.MagicMock(json={})
+        response = mock.MagicMock()
+        response.json.return_value = {}
         items = self.feed.get_response_items(response)
         self.assertEqual(len(items), 0)
 
@@ -423,7 +425,8 @@ class AdvancedFeedTestCase(VimeoTestCase):
         returned.
 
         """
-        response = mock.MagicMock(json={})
+        response = mock.MagicMock()
+        response.json.return_value = {}
         data = self.feed.data_from_response(response)
         self.assertEqual(data, {'video_count': 0})
 


### PR DESCRIPTION
This fixes all the json -> json() calls. Everything in the test suite passes, so I think it's good to go.
